### PR TITLE
fix(agent-runner): stream every assistant text block, not just final result

### DIFF
--- a/container/agent-runner/src/index.ts
+++ b/container/agent-runner/src/index.ts
@@ -501,6 +501,30 @@ async function runQuery(
 
     if (message.type === 'assistant' && 'uuid' in message) {
       lastAssistantUuid = (message as { uuid: string }).uuid;
+
+      // Stream every assistant text block to the host as it arrives.
+      // The SDK's `result` message only carries the *final* assistant text
+      // after end_turn. When the agent iterates within one query
+      // (answer -> tool_use -> tool_result -> reflection), earlier text
+      // blocks would be lost — and if the final block is wrapped in
+      // <internal>...</internal>, the host strips it and sends nothing,
+      // losing the user-facing answer entirely. Emitting per-assistant
+      // ensures every text block is dispatched.
+      const assistantMsg = message as {
+        message?: { content?: Array<{ type: string; text?: string }> };
+      };
+      const assistantText = (assistantMsg.message?.content ?? [])
+        .filter((c) => c.type === 'text' && typeof c.text === 'string')
+        .map((c) => c.text as string)
+        .join('');
+      if (assistantText.trim()) {
+        log(`Streaming assistant text (${assistantText.length} chars)`);
+        writeOutput({
+          status: 'success',
+          result: assistantText,
+          newSessionId,
+        });
+      }
     }
 
     if (message.type === 'system' && message.subtype === 'init') {
@@ -529,9 +553,12 @@ async function runQuery(
       log(
         `Result #${resultCount}: subtype=${message.subtype}${textResult ? ` text=${textResult.slice(0, 200)}` : ''}`,
       );
+      // Text was already streamed via the assistant branch above.
+      // Emit a session-update marker only (result: null) to avoid
+      // double-sending the final block to the user.
       writeOutput({
         status: 'success',
-        result: textResult || null,
+        result: null,
         newSessionId,
       });
     }

--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -132,7 +132,9 @@ function currentApp() {
   return appRef.current;
 }
 
-async function triggerMessageEvent(event: ReturnType<typeof createMessageEvent>) {
+async function triggerMessageEvent(
+  event: ReturnType<typeof createMessageEvent>,
+) {
   const handler = currentApp().eventHandlers.get('message');
   if (handler) await handler({ event });
 }
@@ -309,7 +311,10 @@ describe('SlackChannel', () => {
       const channel = new SlackChannel(opts);
       await channel.connect();
 
-      const event = createMessageEvent({ user: 'U_BOT_123', text: 'Self message' });
+      const event = createMessageEvent({
+        user: 'U_BOT_123',
+        text: 'Self message',
+      });
       await triggerMessageEvent(event);
 
       expect(opts.onMessage).toHaveBeenCalledWith(
@@ -391,13 +396,17 @@ describe('SlackChannel', () => {
       await channel.connect();
 
       // First message — API call
-      await triggerMessageEvent(createMessageEvent({ user: 'U_USER_456', text: 'First' }));
+      await triggerMessageEvent(
+        createMessageEvent({ user: 'U_USER_456', text: 'First' }),
+      );
       // Second message — should use cache
-      await triggerMessageEvent(createMessageEvent({
-        user: 'U_USER_456',
-        text: 'Second',
-        ts: '1704067201.000000',
-      }));
+      await triggerMessageEvent(
+        createMessageEvent({
+          user: 'U_USER_456',
+          text: 'Second',
+          ts: '1704067201.000000',
+        }),
+      );
 
       expect(currentApp().client.users.info).toHaveBeenCalledTimes(1);
     });
@@ -407,7 +416,9 @@ describe('SlackChannel', () => {
       const channel = new SlackChannel(opts);
       await channel.connect();
 
-      currentApp().client.users.info.mockRejectedValueOnce(new Error('API error'));
+      currentApp().client.users.info.mockRejectedValueOnce(
+        new Error('API error'),
+      );
 
       const event = createMessageEvent({ user: 'U_UNKNOWN', text: 'Hi' });
       await triggerMessageEvent(event);
@@ -812,17 +823,13 @@ describe('SlackChannel', () => {
       const channel = new SlackChannel(opts);
 
       // First page returns a cursor; second page returns no cursor
-      currentApp().client.conversations.list
-        .mockResolvedValueOnce({
-          channels: [
-            { id: 'C001', name: 'general', is_member: true },
-          ],
+      currentApp()
+        .client.conversations.list.mockResolvedValueOnce({
+          channels: [{ id: 'C001', name: 'general', is_member: true }],
           response_metadata: { next_cursor: 'cursor_page2' },
         })
         .mockResolvedValueOnce({
-          channels: [
-            { id: 'C002', name: 'random', is_member: true },
-          ],
+          channels: [{ id: 'C002', name: 'random', is_member: true }],
           response_metadata: {},
         });
 
@@ -830,7 +837,8 @@ describe('SlackChannel', () => {
 
       // Should have called conversations.list twice (once per page)
       expect(currentApp().client.conversations.list).toHaveBeenCalledTimes(2);
-      expect(currentApp().client.conversations.list).toHaveBeenNthCalledWith(2,
+      expect(currentApp().client.conversations.list).toHaveBeenNthCalledWith(
+        2,
         expect.objectContaining({ cursor: 'cursor_page2' }),
       );
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -94,8 +94,7 @@ export class SlackChannel implements Channel {
       const groups = this.opts.registeredGroups();
       if (!groups[jid]) return;
 
-      const isBotMessage =
-        !!msg.bot_id || msg.user === this.botUserId;
+      const isBotMessage = !!msg.bot_id || msg.user === this.botUserId;
 
       let senderName: string;
       if (isBotMessage) {
@@ -113,7 +112,10 @@ export class SlackChannel implements Channel {
       let content = msg.text;
       if (this.botUserId && !isBotMessage) {
         const mentionPattern = `<@${this.botUserId}>`;
-        if (content.includes(mentionPattern) && !TRIGGER_PATTERN.test(content)) {
+        if (
+          content.includes(mentionPattern) &&
+          !TRIGGER_PATTERN.test(content)
+        ) {
           content = `@${ASSISTANT_NAME} ${content}`;
         }
       }
@@ -142,10 +144,7 @@ export class SlackChannel implements Channel {
       this.botUserId = auth.user_id as string;
       logger.info({ botUserId: this.botUserId }, 'Connected to Slack');
     } catch (err) {
-      logger.warn(
-        { err },
-        'Connected to Slack but failed to get bot user ID',
-      );
+      logger.warn({ err }, 'Connected to Slack but failed to get bot user ID');
     }
 
     this.connected = true;
@@ -245,9 +244,7 @@ export class SlackChannel implements Channel {
     }
   }
 
-  private async resolveUserName(
-    userId: string,
-  ): Promise<string | undefined> {
+  private async resolveUserName(userId: string): Promise<string | undefined> {
     if (!userId) return undefined;
 
     const cached = this.userNameCache.get(userId);

--- a/src/db.ts
+++ b/src/db.ts
@@ -149,15 +149,11 @@ function createSchema(database: Database.Database): void {
 
   // Add reply context columns if they don't exist (migration for existing DBs)
   try {
-    database.exec(
-      `ALTER TABLE messages ADD COLUMN reply_to_message_id TEXT`,
-    );
+    database.exec(`ALTER TABLE messages ADD COLUMN reply_to_message_id TEXT`);
     database.exec(
       `ALTER TABLE messages ADD COLUMN reply_to_message_content TEXT`,
     );
-    database.exec(
-      `ALTER TABLE messages ADD COLUMN reply_to_sender_name TEXT`,
-    );
+    database.exec(`ALTER TABLE messages ADD COLUMN reply_to_sender_name TEXT`);
   } catch {
     /* columns already exist */
   }


### PR DESCRIPTION
## Summary

The container runner only emitted output to the host on SDK `type: 'result'` messages, which carry only the *final* assistant text after `end_turn`. When the agent iterated within one query (answer → tool_use → tool_result → reflection), every earlier text block was dropped. If the final block happened to be wrapped in `<internal>...</internal>`, the host stripped it and sent nothing — losing the user-facing answer entirely.

## Captured live

An agent answered a question with a 3.4KB markdown response, then a background research subagent returned with confirming data, and the agent added two `<internal>` reflection blocks. The Claude Agent SDK emitted **one** `result` message containing only the last `<internal>` block. The host correctly stripped the internal tags → empty string → nothing dispatched to the channel. The user re-asked thinking the agent hadn't responded.

The 3.4KB answer existed in the session jsonl on disk the whole time. It just never made it past the runner.

## Fix

Extract text from each `assistant` message as it arrives and emit it via `writeOutput`. The `result` message becomes a session-update marker only (`result: null`) to prevent double-sending the final block.

## Why this is safe

- **Host already handles streaming.** `src/index.ts` loops over each `onOutput` callback, strips `<internal>` blocks, sends if non-empty, sets `outputSentToUser`. Multiple text blocks per turn are already a supported code path — the runner just wasn't producing them.
- **No partial-chunk risk.** Without `partialMessages: true`, the SDK emits one complete `assistant` message per LLM response. No streaming token chunks to filter.
- **Internal-only blocks still get suppressed.** Host's regex strips `<internal>...</internal>`; if the result is empty after stripping, it's skipped.
- **No double-sends.** Setting `result: null` on the `result` message prevents the final-text-double-send. Idle timer reset still works (host resets on every `onOutput`, including `result: null`).
- **Cursor / retry semantics unchanged.** `outputSentToUser` is set on the first sent block, so error rollback still works correctly.

## Test plan

- [ ] Typecheck: `cd container/agent-runner && npx tsc --noEmit` — clean (verified locally)
- [ ] Trigger an agent action that produces multiple text blocks across one query (e.g., answer + tool call + reflection). Confirm each non-internal block lands in the channel.
- [ ] Confirm a single-block response still arrives exactly once (no double-send from `result` event).
- [ ] Confirm an `<internal>`-only final block still results in silence (existing behavior).
- [ ] Verify pm2 daemon log shows `Streaming assistant text` lines per dispatched block.

## Notes for reviewers

A regression test would mock the SDK iterator emitting `[assistant#1, tool_use, tool_result, assistant#2(internal), result]` and assert `writeOutput` is called once (for assistant#1 text only). `container/agent-runner/` doesn't currently have a test harness — happy to set one up in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)