### PR TITLE
feat(slack): add socket health check with auto-reconnect

### DIFF
--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -17,6 +17,9 @@ import {
 // Messages exceeding this are split into sequential chunks.
 const MAX_MESSAGE_LENGTH = 4000;
 
+// Health check interval: ping Slack every 5 minutes to detect stale sockets.
+const HEALTH_CHECK_MS = 5 * 60 * 1000;
+
 // The message subtypes we process. Bolt delivers all subtypes via app.event('message');
 // we filter to regular messages (GenericMessageEvent, subtype undefined) and bot messages
 // (BotMessageEvent, subtype 'bot_message') so we can track our own output.
@@ -37,6 +40,8 @@ export class SlackChannel implements Channel {
   private outgoingQueue: Array<{ jid: string; text: string }> = [];
   private flushing = false;
   private userNameCache = new Map<string, string>();
+  private healthTimer: ReturnType<typeof setInterval> | undefined;
+  private reconnecting = false;
 
   private opts: SlackChannelOpts;
 
@@ -155,6 +160,9 @@ export class SlackChannel implements Channel {
 
     // Sync channel names on startup
     await this.syncChannelMetadata();
+
+    // Start periodic health checks to detect stale sockets
+    this.startHealthCheck();
   }
 
   async sendMessage(jid: string, text: string): Promise<void> {
@@ -200,6 +208,10 @@ export class SlackChannel implements Channel {
   }
 
   async disconnect(): Promise<void> {
+    if (this.healthTimer) {
+      clearInterval(this.healthTimer);
+      this.healthTimer = undefined;
+    }
     this.connected = false;
     await this.app.stop();
   }
@@ -261,6 +273,43 @@ export class SlackChannel implements Channel {
     } catch (err) {
       logger.debug({ userId, err }, 'Failed to resolve Slack user name');
       return undefined;
+    }
+  }
+
+  private startHealthCheck(): void {
+    this.healthTimer = setInterval(() => {
+      this.checkHealth().catch(() => {});
+    }, HEALTH_CHECK_MS);
+  }
+
+  private async checkHealth(): Promise<void> {
+    if (!this.connected || this.reconnecting) return;
+    try {
+      await this.app.client.auth.test();
+    } catch (err) {
+      logger.warn({ err }, 'Slack health check failed, reconnecting');
+      await this.reconnect();
+    }
+  }
+
+  private async reconnect(): Promise<void> {
+    if (this.reconnecting) return;
+    this.reconnecting = true;
+    try {
+      this.connected = false;
+      try { await this.app.stop(); } catch { /* already stopped */ }
+      await this.app.start();
+      try {
+        const auth = await this.app.client.auth.test();
+        this.botUserId = auth.user_id as string;
+      } catch { /* non-fatal */ }
+      this.connected = true;
+      logger.info('Slack reconnected after health check failure');
+      await this.flushOutgoingQueue();
+    } catch (err) {
+      logger.error({ err }, 'Slack reconnect failed');
+    } finally {
+      this.reconnecting = false;
     }
   }
 


### PR DESCRIPTION
<!-- contributing-guide: v1 -->
## Type of Change

- [x] **Fix** - bug fix or security fix to source code

## Description

Pings Slack every 5 minutes via auth.test to detect stale sockets. On failure, stops and restarts the app, then flushes queued messages.
