### PR TITLE
Add Slack reaction support

### DIFF
--- a/src/channels/slack.test.ts
+++ b/src/channels/slack.test.ts
@@ -24,6 +24,9 @@ vi.mock('../logger.js', () => ({
 // Mock db
 vi.mock('../db.js', () => ({
   updateChatName: vi.fn(),
+  storeReaction: vi.fn(),
+  removeReaction: vi.fn(),
+  getLatestMessage: vi.fn(() => ({ id: '1704067200.000000', fromMe: false })),
 }));
 
 // --- @slack/bolt mock ---
@@ -56,6 +59,10 @@ vi.mock('@slack/bolt', () => ({
           user: { real_name: 'Alice Smith', name: 'alice' },
         }),
       },
+      reactions: {
+        add: vi.fn().mockResolvedValue({ ok: true }),
+        remove: vi.fn().mockResolvedValue({ ok: true }),
+      },
     };
 
     constructor(opts: any) {
@@ -83,7 +90,12 @@ vi.mock('../env.js', () => ({
 }));
 
 import { SlackChannel, SlackChannelOpts } from './slack.js';
-import { updateChatName } from '../db.js';
+import {
+  updateChatName,
+  storeReaction,
+  removeReaction,
+  getLatestMessage,
+} from '../db.js';
 import { readEnvFile } from '../env.js';
 
 // --- Test helpers ---
@@ -134,6 +146,34 @@ function currentApp() {
 
 async function triggerMessageEvent(event: ReturnType<typeof createMessageEvent>) {
   const handler = currentApp().eventHandlers.get('message');
+  if (handler) await handler({ event });
+}
+
+function createReactionEvent(overrides: {
+  user?: string;
+  reaction?: string;
+  channel?: string;
+  ts?: string;
+  eventTs?: string;
+  itemType?: string;
+}) {
+  return {
+    user: overrides.user ?? 'U_USER_456',
+    reaction: overrides.reaction ?? 'thumbsup',
+    item: {
+      type: overrides.itemType ?? 'message',
+      channel: overrides.channel ?? 'C0123456789',
+      ts: overrides.ts ?? '1704067200.000000',
+    },
+    event_ts: overrides.eventTs ?? '1704067260.000000',
+  };
+}
+
+async function triggerReactionEvent(
+  kind: 'reaction_added' | 'reaction_removed',
+  event: ReturnType<typeof createReactionEvent>,
+) {
+  const handler = currentApp().eventHandlers.get(kind);
   if (handler) await handler({ event });
 }
 
@@ -837,6 +877,190 @@ describe('SlackChannel', () => {
       // Both channels from both pages stored
       expect(updateChatName).toHaveBeenCalledWith('slack:C001', 'general');
       expect(updateChatName).toHaveBeenCalledWith('slack:C002', 'random');
+    });
+  });
+
+  // --- Reactions ---
+
+  describe('reactions', () => {
+    it('registers reaction_added and reaction_removed handlers', () => {
+      new SlackChannel(createTestOpts());
+      expect(currentApp().eventHandlers.has('reaction_added')).toBe(true);
+      expect(currentApp().eventHandlers.has('reaction_removed')).toBe(true);
+    });
+
+    it('stores inbound reaction_added for registered channels', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerReactionEvent(
+        'reaction_added',
+        createReactionEvent({ reaction: 'thumbsup', user: 'U_USER_456' }),
+      );
+
+      expect(storeReaction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message_id: '1704067200.000000',
+          message_chat_jid: 'slack:C0123456789',
+          reactor_jid: 'slack:U_USER_456',
+          emoji: 'thumbsup',
+        }),
+      );
+    });
+
+    it('ignores reactions for unregistered channels', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerReactionEvent(
+        'reaction_added',
+        createReactionEvent({ channel: 'C_UNREGISTERED' }),
+      );
+
+      expect(storeReaction).not.toHaveBeenCalled();
+    });
+
+    it('ignores reaction events on non-message items', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerReactionEvent(
+        'reaction_added',
+        createReactionEvent({ itemType: 'file' }),
+      );
+
+      expect(storeReaction).not.toHaveBeenCalled();
+    });
+
+    it('removes reaction on reaction_removed event', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await triggerReactionEvent(
+        'reaction_removed',
+        createReactionEvent({ reaction: 'thumbsup', user: 'U_USER_456' }),
+      );
+
+      expect(removeReaction).toHaveBeenCalledWith(
+        '1704067200.000000',
+        'slack:C0123456789',
+        'slack:U_USER_456',
+        'thumbsup',
+      );
+      expect(storeReaction).not.toHaveBeenCalled();
+    });
+
+    it('sendReaction calls reactions.add with channel + ts', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await channel.sendReaction(
+        'slack:C0123456789',
+        { id: '1704067200.000000', remoteJid: 'slack:C0123456789' },
+        'thumbsup',
+      );
+
+      expect(currentApp().client.reactions.add).toHaveBeenCalledWith({
+        channel: 'C0123456789',
+        timestamp: '1704067200.000000',
+        name: 'thumbsup',
+      });
+    });
+
+    it('sendReaction strips surrounding colons from shortcodes', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await channel.sendReaction(
+        'slack:C0123456789',
+        { id: '1704067200.000000', remoteJid: 'slack:C0123456789' },
+        ':tada:',
+      );
+
+      expect(currentApp().client.reactions.add).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'tada' }),
+      );
+    });
+
+    it('sendReaction swallows already_reacted errors', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      currentApp().client.reactions.add.mockRejectedValueOnce({
+        data: { error: 'already_reacted' },
+      });
+
+      await expect(
+        channel.sendReaction(
+          'slack:C0123456789',
+          { id: '1704067200.000000', remoteJid: 'slack:C0123456789' },
+          'thumbsup',
+        ),
+      ).resolves.toBeUndefined();
+    });
+
+    it('sendReaction propagates unexpected errors', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      currentApp().client.reactions.add.mockRejectedValueOnce({
+        data: { error: 'channel_not_found' },
+      });
+
+      await expect(
+        channel.sendReaction(
+          'slack:C0123456789',
+          { id: '1704067200.000000', remoteJid: 'slack:C0123456789' },
+          'thumbsup',
+        ),
+      ).rejects.toBeDefined();
+    });
+
+    it('sendReaction throws when disconnected', async () => {
+      const channel = new SlackChannel(createTestOpts());
+      // not calling connect()
+      await expect(
+        channel.sendReaction(
+          'slack:C0123456789',
+          { id: '1704067200.000000', remoteJid: 'slack:C0123456789' },
+          'thumbsup',
+        ),
+      ).rejects.toThrow('Not connected to Slack');
+    });
+
+    it('reactToLatestMessage looks up latest then reacts', async () => {
+      const opts = createTestOpts();
+      const channel = new SlackChannel(opts);
+      await channel.connect();
+
+      await channel.reactToLatestMessage('slack:C0123456789', 'eyes');
+
+      expect(getLatestMessage).toHaveBeenCalledWith('slack:C0123456789');
+      expect(currentApp().client.reactions.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'C0123456789',
+          timestamp: '1704067200.000000',
+          name: 'eyes',
+        }),
+      );
+    });
+
+    it('reactToLatestMessage throws when no messages exist', async () => {
+      (getLatestMessage as any).mockReturnValueOnce(undefined);
+      const channel = new SlackChannel(createTestOpts());
+      await channel.connect();
+
+      await expect(
+        channel.reactToLatestMessage('slack:C0123456789', 'eyes'),
+      ).rejects.toThrow('No messages found');
     });
   });
 

--- a/src/channels/slack.ts
+++ b/src/channels/slack.ts
@@ -2,7 +2,12 @@ import { App, LogLevel } from '@slack/bolt';
 import type { GenericMessageEvent, BotMessageEvent } from '@slack/types';
 
 import { ASSISTANT_NAME, TRIGGER_PATTERN } from '../config.js';
-import { updateChatName } from '../db.js';
+import {
+  getLatestMessage,
+  removeReaction,
+  storeReaction,
+  updateChatName,
+} from '../db.js';
 import { readEnvFile } from '../env.js';
 import { logger } from '../logger.js';
 import { registerChannel, ChannelOpts } from './registry.js';
@@ -129,6 +134,68 @@ export class SlackChannel implements Channel {
         is_bot_message: isBotMessage,
       });
     });
+
+    this.app.event('reaction_added', async ({ event }) => {
+      await this.handleReactionEvent(event, 'added');
+    });
+
+    this.app.event('reaction_removed', async ({ event }) => {
+      await this.handleReactionEvent(event, 'removed');
+    });
+  }
+
+  private async handleReactionEvent(
+    event: {
+      user?: string;
+      reaction?: string;
+      item?: { type?: string; channel?: string; ts?: string };
+      event_ts?: string;
+    },
+    kind: 'added' | 'removed',
+  ): Promise<void> {
+    try {
+      if (!event.item || event.item.type !== 'message') return;
+      const channelId = event.item.channel;
+      const messageId = event.item.ts;
+      const emoji = event.reaction;
+      const reactorUserId = event.user;
+      if (!channelId || !messageId || !emoji || !reactorUserId) return;
+
+      const chatJid = `slack:${channelId}`;
+      const groups = this.opts.registeredGroups();
+      if (!groups[chatJid]) return;
+
+      const timestamp = event.event_ts
+        ? new Date(parseFloat(event.event_ts) * 1000).toISOString()
+        : new Date().toISOString();
+      const reactorJid = `slack:${reactorUserId}`;
+      const reactorName = await this.resolveUserName(reactorUserId);
+
+      if (kind === 'added') {
+        storeReaction({
+          message_id: messageId,
+          message_chat_jid: chatJid,
+          reactor_jid: reactorJid,
+          reactor_name: reactorName,
+          emoji,
+          timestamp,
+        });
+      } else {
+        removeReaction(messageId, chatJid, reactorJid, emoji);
+      }
+
+      logger.info(
+        {
+          chatJid,
+          messageId,
+          reactor: reactorName || reactorUserId,
+          emoji,
+        },
+        kind === 'added' ? 'Slack reaction added' : 'Slack reaction removed',
+      );
+    } catch (err) {
+      logger.error({ err }, 'Failed to process Slack reaction');
+    }
   }
 
   async connect(): Promise<void> {
@@ -189,6 +256,88 @@ export class SlackChannel implements Channel {
         'Failed to send Slack message, queued',
       );
     }
+  }
+
+  /**
+   * Send a reaction to a message.
+   * `emoji` is the Slack shortcode name without surrounding colons
+   * (e.g. `"thumbsup"`, `"+1"`). An empty or falsy value removes the bot's
+   * reaction — Slack requires the original emoji name to remove, which we
+   * can't reconstruct without state, so callers should pass the emoji that
+   * was previously added.
+   */
+  async sendReaction(
+    chatJid: string,
+    messageKey: { id: string; remoteJid: string },
+    emoji: string,
+  ): Promise<void> {
+    if (!this.connected) {
+      logger.warn({ chatJid, emoji }, 'Cannot send reaction - not connected');
+      throw new Error('Not connected to Slack');
+    }
+
+    const channelId = (messageKey.remoteJid || chatJid).replace(/^slack:/, '');
+    const name = this.normalizeEmojiName(emoji);
+
+    try {
+      if (!name) {
+        // Empty emoji is treated as "remove whatever I reacted with" — but
+        // Slack has no "remove all" API, so we no-op and log.
+        logger.warn(
+          { chatJid },
+          'sendReaction called with empty emoji — Slack requires a specific emoji name to remove; no-op',
+        );
+        return;
+      }
+      await this.app.client.reactions.add({
+        channel: channelId,
+        timestamp: messageKey.id,
+        name,
+      });
+      logger.info(
+        { chatJid, messageId: messageKey.id, emoji: name },
+        'Slack reaction sent',
+      );
+    } catch (err) {
+      const errMsg = (err as { data?: { error?: string } })?.data?.error;
+      if (errMsg === 'already_reacted') {
+        logger.debug(
+          { chatJid, emoji: name },
+          'Slack reaction already present, ignoring',
+        );
+        return;
+      }
+      logger.error({ chatJid, emoji: name, err }, 'Failed to send Slack reaction');
+      throw err;
+    }
+  }
+
+  async reactToLatestMessage(chatJid: string, emoji: string): Promise<void> {
+    const latest = getLatestMessage(chatJid);
+    if (!latest) {
+      throw new Error(`No messages found for chat ${chatJid}`);
+    }
+    await this.sendReaction(
+      chatJid,
+      { id: latest.id, remoteJid: chatJid },
+      emoji,
+    );
+  }
+
+  /**
+   * Normalize an emoji input to the Slack shortcode name used by the
+   * reactions API. Accepts:
+   *   - bare shortcode   → `thumbsup`
+   *   - wrapped shortcode → `:thumbsup:`
+   *   - unicode emoji    → currently unsupported, returned as-is
+   */
+  private normalizeEmojiName(emoji: string): string {
+    if (!emoji) return '';
+    const trimmed = emoji.trim();
+    if (trimmed.startsWith(':') && trimmed.endsWith(':')) {
+      return trimmed.slice(1, -1);
+    }
+    return trimmed;
   }
 
   isConnected(): boolean {

--- a/src/db.ts
+++ b/src/db.ts
@@ -82,6 +82,20 @@ function createSchema(database: Database.Database): void {
       container_config TEXT,
       requires_trigger INTEGER DEFAULT 1
     );
+
+    CREATE TABLE IF NOT EXISTS reactions (
+      message_id TEXT NOT NULL,
+      message_chat_jid TEXT NOT NULL,
+      reactor_jid TEXT NOT NULL,
+      reactor_name TEXT,
+      emoji TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      PRIMARY KEY (message_id, message_chat_jid, reactor_jid)
+    );
+    CREATE INDEX IF NOT EXISTS idx_reactions_message ON reactions(message_id, message_chat_jid);
+    CREATE INDEX IF NOT EXISTS idx_reactions_reactor ON reactions(reactor_jid);
+    CREATE INDEX IF NOT EXISTS idx_reactions_emoji ON reactions(emoji);
+    CREATE INDEX IF NOT EXISTS idx_reactions_timestamp ON reactions(timestamp);
   `);
 
   // Add context_mode column if it doesn't exist (migration for existing DBs)
@@ -281,6 +295,71 @@ export function setLastGroupSync(): void {
   db.prepare(
     `INSERT OR REPLACE INTO chats (jid, name, last_message_time) VALUES ('__group_sync__', '__group_sync__', ?)`,
   ).run(now);
+}
+
+export interface Reaction {
+  message_id: string;
+  message_chat_jid: string;
+  reactor_jid: string;
+  reactor_name?: string;
+  emoji: string;
+  timestamp: string;
+}
+
+/**
+ * Store or remove a reaction. Passing an empty emoji removes any existing
+ * reaction from `reactor_jid` on the target message.
+ */
+export function storeReaction(reaction: Reaction): void {
+  if (!reaction.emoji) {
+    db.prepare(
+      `DELETE FROM reactions WHERE message_id = ? AND message_chat_jid = ? AND reactor_jid = ?`,
+    ).run(
+      reaction.message_id,
+      reaction.message_chat_jid,
+      reaction.reactor_jid,
+    );
+    return;
+  }
+  db.prepare(
+    `INSERT OR REPLACE INTO reactions (message_id, message_chat_jid, reactor_jid, reactor_name, emoji, timestamp)
+     VALUES (?, ?, ?, ?, ?, ?)`,
+  ).run(
+    reaction.message_id,
+    reaction.message_chat_jid,
+    reaction.reactor_jid,
+    reaction.reactor_name || null,
+    reaction.emoji,
+    reaction.timestamp,
+  );
+}
+
+/**
+ * Remove a specific (reactor_jid, emoji) reaction. Used by channels like Slack
+ * that deliver explicit reaction_removed events per emoji.
+ */
+export function removeReaction(
+  messageId: string,
+  chatJid: string,
+  reactorJid: string,
+  emoji: string,
+): void {
+  db.prepare(
+    `DELETE FROM reactions
+     WHERE message_id = ? AND message_chat_jid = ? AND reactor_jid = ? AND emoji = ?`,
+  ).run(messageId, chatJid, reactorJid, emoji);
+}
+
+export function getLatestMessage(
+  chatJid: string,
+): { id: string; fromMe: boolean } | undefined {
+  const row = db
+    .prepare(
+      `SELECT id, is_from_me FROM messages WHERE chat_jid = ? ORDER BY timestamp DESC LIMIT 1`,
+    )
+    .get(chatJid) as { id: string; is_from_me: number | null } | undefined;
+  if (!row) return undefined;
+  return { id: row.id, fromMe: row.is_from_me === 1 };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,6 +95,19 @@ export interface Channel {
   setTyping?(jid: string, isTyping: boolean): Promise<void>;
   // Optional: sync group/chat names from the platform.
   syncGroups?(force: boolean): Promise<void>;
+  // Optional: reaction support. `messageKey` is channel-specific (Slack uses
+  // `{ id: ts, remoteJid: jid }`, WhatsApp includes participant/fromMe).
+  sendReaction?(
+    chatJid: string,
+    messageKey: {
+      id: string;
+      remoteJid: string;
+      fromMe?: boolean;
+      participant?: string;
+    },
+    emoji: string,
+  ): Promise<void>;
+  reactToLatestMessage?(chatJid: string, emoji: string): Promise<void>;
 }
 
 // Callback type that channels use to deliver inbound messages


### PR DESCRIPTION
## Summary

Adds emoji reaction handling to the Slack channel, mirroring the optional `sendReaction` / `reactToLatestMessage` contract already used by the WhatsApp skill.

- Subscribes to `reaction_added` / `reaction_removed` and persists them to a `reactions` table (only for registered channels)
- Implements `sendReaction()` via `reactions.add` and `reactToLatestMessage()` via a lookup on the latest stored message
- Adds the shared `reactions` table plus `storeReaction` / `removeReaction` / `getLatestMessage` helpers to `db.ts` so the Slack skill is self-contained. Schema is intentionally identical to the WhatsApp reactions skill (`CREATE TABLE IF NOT EXISTS` makes composition safe)
- Adds the optional `sendReaction` / `reactToLatestMessage` hooks to the `Channel` interface in `types.ts`
- 12 new unit tests cover add/remove flows, unregistered-channel filtering, non-message items, emoji shortcode normalization (`:tada:` → `tada`), `already_reacted` handling, disconnect guards, and the `reactToLatestMessage` path

## Required Slack app config

- **Bot token scopes**: `reactions:read`, `reactions:write`
- **Bot events**: `reaction_added`, `reaction_removed`

Reinstall the app to your workspace after adding scopes.

## Notes

- Reactor identity is stored as `slack:U<userid>` to stay consistent with the `slack:C<channelid>` chat JID format used elsewhere in the channel.
- Slack's `reactions.add` expects a shortcode name (e.g. `thumbsup`), not the Unicode character. The implementation accepts both `thumbsup` and `:thumbsup:` (strips surrounding colons). Passing an actual emoji character will currently fail with `invalid_name` — mapping Unicode → shortcode is left as a future improvement.
- `sendReaction` with an empty emoji is a no-op on Slack (the API requires a specific name to remove, unlike WhatsApp where an empty text clears whatever reaction the user had).
- `already_reacted` errors from `reactions.add` are swallowed silently — reasserting the bot's own reaction is idempotent behavior.

## Test plan

- [x] `npx vitest run src/channels/slack.test.ts` — all 58 tests pass (46 existing + 12 new)
- [x] `npm run build` — clean
- [x] `npx vitest run` — full suite (304 tests) passes
- [x] Tested live against a real Slack workspace: `reaction_added` events correctly insert rows and `reaction_removed` deletes them